### PR TITLE
Add dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+LICENSE
+README.md
+tmp/
+.dockerignore
+.gitignore
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+
+# Build the application from source
+FROM golang:1.21 AS builder
+
+WORKDIR /app
+
+COPY go.* ./
+RUN go mod download
+
+COPY . .
+
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH}  go build -o morphos .
+
+# Deploy the application binary into a lean image
+FROM debian:bookworm-slim AS release
+
+WORKDIR /
+
+COPY --from=builder /app/morphos /bin/morphos
+
+EXPOSE 8080
+
+ENTRYPOINT ["/bin/morphos"]

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,19 @@ download-htmx:
 download-bootstrap:
 	curl -o static/bootstrap.min.css https://cdn.jsdelivr.net/npm/bootstrap@${BOOTSTRAP_VERSION}/dist/css/bootstrap.min.css
 	curl -o static/bootstrap.min.js https://cdn.jsdelivr.net/npm/bootstrap@${BOOTSTRAP_VERSION}/dist/js/bootstrap.bundle.min.js
+
+.PHONY: build
+## build: Builds the container image
+build:
+	docker build -t morphos .
+
+.PHONY: docker-run
+## docker-run: Runs the container
+docker-run:
+	docker run -d -p 8080:8080 morphos
+
+.PHONY: help
+## help: Prints this help message
+help:
+	@echo "Usage:"
+	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' |  sed -e 's/^/ /'

--- a/main.go
+++ b/main.go
@@ -206,7 +206,7 @@ func main() {
 	r.Post("/format", handleFileFormat)
 	r.Get("/modal", handleModal)
 
-	http.ListenAndServe("localhost:8080", r)
+	http.ListenAndServe(":8080", r)
 }
 
 func renderError(w http.ResponseWriter, message string, statusCode int) {


### PR DESCRIPTION
## Changes
* Remove the localhost from the `ListenAndServe` function
* Add a `Dockerfile` to build the container image
* Add a `.dockerignore` file
* Add target commands to the `Makefile` to run and build the container image

I'm using debian:bookworm-slim as a final stage image just in case we need external dependencies available for Debian-like systems.

Image built on my machine (GOOS=linux and GOARCH=amd64) is just 86.4 MB size. I can be smaller if I manage to avoid to use external dependencies.