### PR TITLE
Add tiff and bmp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21.3
 
 require (
 	github.com/chai2010/webp v1.1.1
+	github.com/gabriel-vasile/mimetype v1.4.3
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/image v0.14.0
@@ -12,5 +13,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.18.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/chai2010/webp v1.1.1 h1:jTRmEccAJ4MGrhFOrPMpNGIJ/eybIgwKpcACsrTEapk=
 github.com/chai2010/webp v1.1.1/go.mod h1:0XVwvZWdjjdxpUEIf7b9g9VkHFnInUSYujwqTLEuldU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
+github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
 github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -10,6 +12,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/image v0.14.0 h1:tNgSxAFe3jC4uYqvZdTr84SZoM1KfwdC9SKIFrLjFn4=
 golang.org/x/image v0.14.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=
+golang.org/x/net v0.18.0 h1:mIYleuAkSbHh0tCv7RvjL3F6ZVbLjq4+R7zbOn3Kokg=
+golang.org/x/net v0.18.0/go.mod h1:/czyP5RqHAH4odGYxBJ1qz0+CE5WZ+2j1YgoEo8F2jQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/files/images/images.go
+++ b/pkg/files/images/images.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/chai2010/webp"
+	"golang.org/x/image/tiff"
 	webpx "golang.org/x/image/webp"
 )
 
@@ -19,6 +20,8 @@ const (
 	JPG  = "jpg"
 	GIF  = "gif"
 	WEBP = "webp"
+	TIFF = "tiff"
+	BMP  = "bmp"
 
 	imageMimeType = "image/"
 )
@@ -62,6 +65,8 @@ func ConverImage(from, to string, imageBytes []byte) ([]byte, error) {
 		}
 	case WEBP:
 		img, err = webpx.Decode(bytes.NewReader(imageBytes))
+	case TIFF:
+		img, err = tiff.Decode(bytes.NewReader(imageBytes))
 	default:
 		return nil, fmt.Errorf("file format %s not supported", from)
 	}
@@ -84,6 +89,11 @@ func ConverImage(from, to string, imageBytes []byte) ([]byte, error) {
 		}
 	case WEBP:
 		result, err = toWEBP(img)
+		if err != nil {
+			return nil, err
+		}
+	case TIFF:
+		result, err = toTIFF(img)
 		if err != nil {
 			return nil, err
 		}
@@ -138,6 +148,17 @@ func toWEBP(img image.Image) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func toTIFF(img image.Image) ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	// encode the image as a TIFF file.
+	if err := tiff.Encode(buf, img, nil); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
 func FileFormatsToConvert(to string) map[string][]FileFormat {
 	formats := make(map[string][]FileFormat)
 
@@ -150,6 +171,7 @@ func FileFormatsToConvert(to string) map[string][]FileFormat {
 				{Name: PNG},
 				{Name: GIF},
 				{Name: WEBP},
+				{Name: TIFF},
 			},
 		}
 	case PNG:
@@ -158,6 +180,7 @@ func FileFormatsToConvert(to string) map[string][]FileFormat {
 				{Name: JPG},
 				{Name: GIF},
 				{Name: WEBP},
+				{Name: TIFF},
 			},
 		}
 	case GIF:
@@ -166,6 +189,7 @@ func FileFormatsToConvert(to string) map[string][]FileFormat {
 				{Name: JPG},
 				{Name: PNG},
 				{Name: WEBP},
+				{Name: TIFF},
 			},
 		}
 	case WEBP:
@@ -174,6 +198,16 @@ func FileFormatsToConvert(to string) map[string][]FileFormat {
 				{Name: JPG},
 				{Name: PNG},
 				{Name: GIF},
+				{Name: TIFF},
+			},
+		}
+	case TIFF:
+		formats = map[string][]FileFormat{
+			"Formats": {
+				{Name: JPG},
+				{Name: PNG},
+				{Name: GIF},
+				{Name: WEBP},
 			},
 		}
 	}

--- a/pkg/files/images/images.go
+++ b/pkg/files/images/images.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/chai2010/webp"
+	"golang.org/x/image/bmp"
 	"golang.org/x/image/tiff"
 	webpx "golang.org/x/image/webp"
 )
@@ -65,8 +66,19 @@ func ConverImage(from, to string, imageBytes []byte) ([]byte, error) {
 		}
 	case WEBP:
 		img, err = webpx.Decode(bytes.NewReader(imageBytes))
+		if err != nil {
+			return nil, err
+		}
 	case TIFF:
 		img, err = tiff.Decode(bytes.NewReader(imageBytes))
+		if err != nil {
+			return nil, err
+		}
+	case BMP:
+		img, err = bmp.Decode(bytes.NewReader(imageBytes))
+		if err != nil {
+			return nil, err
+		}
 	default:
 		return nil, fmt.Errorf("file format %s not supported", from)
 	}
@@ -94,6 +106,11 @@ func ConverImage(from, to string, imageBytes []byte) ([]byte, error) {
 		}
 	case TIFF:
 		result, err = toTIFF(img)
+		if err != nil {
+			return nil, err
+		}
+	case BMP:
+		result, err = toBMP(img)
 		if err != nil {
 			return nil, err
 		}
@@ -159,6 +176,16 @@ func toTIFF(img image.Image) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func toBMP(img image.Image) ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	if err := bmp.Encode(buf, img); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
 func FileFormatsToConvert(to string) map[string][]FileFormat {
 	formats := make(map[string][]FileFormat)
 
@@ -172,6 +199,7 @@ func FileFormatsToConvert(to string) map[string][]FileFormat {
 				{Name: GIF},
 				{Name: WEBP},
 				{Name: TIFF},
+				{Name: BMP},
 			},
 		}
 	case PNG:
@@ -181,6 +209,7 @@ func FileFormatsToConvert(to string) map[string][]FileFormat {
 				{Name: GIF},
 				{Name: WEBP},
 				{Name: TIFF},
+				{Name: BMP},
 			},
 		}
 	case GIF:
@@ -190,6 +219,7 @@ func FileFormatsToConvert(to string) map[string][]FileFormat {
 				{Name: PNG},
 				{Name: WEBP},
 				{Name: TIFF},
+				{Name: BMP},
 			},
 		}
 	case WEBP:
@@ -199,6 +229,7 @@ func FileFormatsToConvert(to string) map[string][]FileFormat {
 				{Name: PNG},
 				{Name: GIF},
 				{Name: TIFF},
+				{Name: BMP},
 			},
 		}
 	case TIFF:
@@ -208,10 +239,20 @@ func FileFormatsToConvert(to string) map[string][]FileFormat {
 				{Name: PNG},
 				{Name: GIF},
 				{Name: WEBP},
+				{Name: BMP},
+			},
+		}
+	case BMP:
+		formats = map[string][]FileFormat{
+			"Formats": {
+				{Name: JPG},
+				{Name: PNG},
+				{Name: GIF},
+				{Name: WEBP},
+				{Name: TIFF},
 			},
 		}
 	}
-
 	return formats
 }
 

--- a/pkg/files/images/images_test.go
+++ b/pkg/files/images/images_test.go
@@ -67,6 +67,18 @@ func TestConvertImage(t *testing.T) {
 				mimetype: "image/webp",
 			},
 		},
+		{
+			name: "webp to tiff",
+			input: input{
+				filename:     "testdata/gopher.webp",
+				mimetype:     "image/webp",
+				targetFormat: "tiff",
+			},
+			expected: expected{
+				// Seems http.DetectContentType can not detect image/tiff.
+				mimetype: "application/octet-stream",
+			},
+		},
 	}
 	for _, tc := range tests {
 		tc := tc
@@ -109,6 +121,7 @@ func TestFileFormatsToConvert(t *testing.T) {
 					{Name: images.PNG},
 					{Name: images.GIF},
 					{Name: images.WEBP},
+					{Name: images.TIFF},
 				},
 			},
 		},
@@ -122,6 +135,7 @@ func TestFileFormatsToConvert(t *testing.T) {
 					{Name: images.JPG},
 					{Name: images.GIF},
 					{Name: images.WEBP},
+					{Name: images.TIFF},
 				},
 			},
 		},
@@ -135,6 +149,7 @@ func TestFileFormatsToConvert(t *testing.T) {
 					{Name: images.JPG},
 					{Name: images.PNG},
 					{Name: images.WEBP},
+					{Name: images.TIFF},
 				},
 			},
 		},
@@ -148,6 +163,21 @@ func TestFileFormatsToConvert(t *testing.T) {
 					{Name: images.JPG},
 					{Name: images.PNG},
 					{Name: images.GIF},
+					{Name: images.TIFF},
+				},
+			},
+		},
+		{
+			name: "TIFF",
+			input: input{
+				format: images.TIFF,
+			},
+			expected: expected{
+				targetFormats: []images.FileFormat{
+					{Name: images.JPG},
+					{Name: images.PNG},
+					{Name: images.GIF},
+					{Name: images.WEBP},
 				},
 			},
 		},

--- a/pkg/files/images/images_test.go
+++ b/pkg/files/images/images_test.go
@@ -1,11 +1,11 @@
 package images_test
 
 import (
-	"net/http"
 	"os"
 	"testing"
 
 	"github.com/danvergara/morphos/pkg/files/images"
+	"github.com/gabriel-vasile/mimetype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -75,8 +75,29 @@ func TestConvertImage(t *testing.T) {
 				targetFormat: "tiff",
 			},
 			expected: expected{
-				// Seems http.DetectContentType can not detect image/tiff.
-				mimetype: "application/octet-stream",
+				mimetype: "image/tiff",
+			},
+		},
+		{
+			name: "bmp to png",
+			input: input{
+				filename:     "testdata/sunset.bmp",
+				mimetype:     "image/bmp",
+				targetFormat: "png",
+			},
+			expected: expected{
+				mimetype: "image/png",
+			},
+		},
+		{
+			name: "jpg to bmp",
+			input: input{
+				filename:     "testdata/Golang_Gopher.jpg",
+				mimetype:     "image/jpeg",
+				targetFormat: "bmp",
+			},
+			expected: expected{
+				mimetype: "image/bmp",
 			},
 		},
 	}
@@ -86,14 +107,14 @@ func TestConvertImage(t *testing.T) {
 			inputImg, err := os.ReadFile(tc.input.filename)
 			require.NoError(t, err)
 
-			detectedFileType := http.DetectContentType(inputImg)
-			require.Equal(t, tc.input.mimetype, detectedFileType)
+			detectedFileType := mimetype.Detect(inputImg)
+			require.Equal(t, tc.input.mimetype, detectedFileType.String())
 
-			convertedImg, err := images.ConverImage(detectedFileType, tc.input.targetFormat, inputImg)
+			convertedImg, err := images.ConverImage(detectedFileType.String(), tc.input.targetFormat, inputImg)
 			require.NoError(t, err)
 
-			detectedFileType = http.DetectContentType(convertedImg)
-			require.Equal(t, tc.expected.mimetype, detectedFileType)
+			detectedFileType = mimetype.Detect(convertedImg)
+			require.Equal(t, tc.expected.mimetype, detectedFileType.String())
 		})
 	}
 }
@@ -122,6 +143,7 @@ func TestFileFormatsToConvert(t *testing.T) {
 					{Name: images.GIF},
 					{Name: images.WEBP},
 					{Name: images.TIFF},
+					{Name: images.BMP},
 				},
 			},
 		},
@@ -136,6 +158,7 @@ func TestFileFormatsToConvert(t *testing.T) {
 					{Name: images.GIF},
 					{Name: images.WEBP},
 					{Name: images.TIFF},
+					{Name: images.BMP},
 				},
 			},
 		},
@@ -150,6 +173,7 @@ func TestFileFormatsToConvert(t *testing.T) {
 					{Name: images.PNG},
 					{Name: images.WEBP},
 					{Name: images.TIFF},
+					{Name: images.BMP},
 				},
 			},
 		},
@@ -164,6 +188,7 @@ func TestFileFormatsToConvert(t *testing.T) {
 					{Name: images.PNG},
 					{Name: images.GIF},
 					{Name: images.TIFF},
+					{Name: images.BMP},
 				},
 			},
 		},
@@ -178,6 +203,22 @@ func TestFileFormatsToConvert(t *testing.T) {
 					{Name: images.PNG},
 					{Name: images.GIF},
 					{Name: images.WEBP},
+					{Name: images.BMP},
+				},
+			},
+		},
+		{
+			name: "BMP",
+			input: input{
+				format: images.BMP,
+			},
+			expected: expected{
+				targetFormats: []images.FileFormat{
+					{Name: images.JPG},
+					{Name: images.PNG},
+					{Name: images.GIF},
+					{Name: images.WEBP},
+					{Name: images.TIFF},
 				},
 			},
 		},


### PR DESCRIPTION
This PR introduces the `TIFF` and `BMP`  image formats and the ability to convert from and to this file formats from the other supported image formats.

This is possible due to the [image package](https://pkg.go.dev/golang.org/x/image) from the experimental libraries.