### PR TITLE
Add a workflow to push the container image to GitHub's container registry

### DIFF
--- a/.github/workflows/deploy_image.yml
+++ b/.github/workflows/deploy_image.yml
@@ -1,0 +1,30 @@
+name: Deploy Morphos Server Container Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  push_morphos_image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.actor }}/morphos-server:latest


### PR DESCRIPTION
## Description

This PR add workflow to push the container image to GitHub's container registry.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Published the image omitting the branch constraint, for testing purposes.

Image is available by running:

`docker pull ghcr.io/danvergara/morphos-server:latest`

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
