### PR TITLE
Add abstract factory

### DIFF
--- a/pkg/files/document_factory.go
+++ b/pkg/files/document_factory.go
@@ -6,8 +6,12 @@ import (
 	"github.com/danvergara/morphos/pkg/files/documents"
 )
 
+// DocumentFactory implements the FileFactory interface.
 type DocumentFactory struct{}
 
+// NewFile method returns an object that implements the File interface,
+// given a document format as input.
+// If not supported, it will error out.
 func (d *DocumentFactory) NewFile(f string) (File, error) {
 	switch f {
 	case documents.PDF:

--- a/pkg/files/document_factory.go
+++ b/pkg/files/document_factory.go
@@ -1,0 +1,20 @@
+package files
+
+import (
+	"fmt"
+
+	"github.com/danvergara/morphos/pkg/files/documents"
+)
+
+type DocumentFactory struct{}
+
+func (d *DocumentFactory) NewFile(f string) (File, error) {
+	switch f {
+	case documents.PDF:
+		return new(documents.Pdf), nil
+	case documents.DOCX:
+		return new(documents.Docx), nil
+	default:
+		return nil, fmt.Errorf("file of type %s not recognized", f)
+	}
+}

--- a/pkg/files/documents.go
+++ b/pkg/files/documents.go
@@ -1,0 +1,5 @@
+package files
+
+type Document interface {
+	DocumentType() string
+}

--- a/pkg/files/documents.go
+++ b/pkg/files/documents.go
@@ -1,5 +1,7 @@
 package files
 
+// Document interface is the one that defines what a document is
+// in this context. It's responsible to return kind of the underlying document.
 type Document interface {
 	DocumentType() string
 }

--- a/pkg/files/documents/documents.go
+++ b/pkg/files/documents/documents.go
@@ -1,0 +1,6 @@
+package documents
+
+const (
+	DOCX = "docx"
+	PDF  = "pdf"
+)

--- a/pkg/files/documents/docx.go
+++ b/pkg/files/documents/docx.go
@@ -1,0 +1,17 @@
+package documents
+
+import "errors"
+
+type Docx struct{}
+
+func (p *Docx) SupportedFormats() map[string]string {
+	return make(map[string]string)
+}
+
+func (p *Docx) ConvertTo(format string) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *Docx) DocumentType() string {
+	return DOCX
+}

--- a/pkg/files/documents/docx.go
+++ b/pkg/files/documents/docx.go
@@ -4,11 +4,11 @@ import "errors"
 
 type Docx struct{}
 
-func (p *Docx) SupportedFormats() map[string]string {
-	return make(map[string]string)
+func (p *Docx) SupportedFormats() map[string][]string {
+	return make(map[string][]string)
 }
 
-func (p *Docx) ConvertTo(format string) ([]byte, error) {
+func (p *Docx) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/pkg/files/documents/pdf.go
+++ b/pkg/files/documents/pdf.go
@@ -1,0 +1,17 @@
+package documents
+
+import "errors"
+
+type Pdf struct{}
+
+func (p *Pdf) SupportedFormats() map[string]string {
+	return make(map[string]string)
+}
+
+func (p *Pdf) ConvertTo(format string) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *Pdf) DocumentType() string {
+	return PDF
+}

--- a/pkg/files/documents/pdf.go
+++ b/pkg/files/documents/pdf.go
@@ -4,11 +4,11 @@ import "errors"
 
 type Pdf struct{}
 
-func (p *Pdf) SupportedFormats() map[string]string {
-	return make(map[string]string)
+func (p *Pdf) SupportedFormats() map[string][]string {
+	return make(map[string][]string)
 }
 
-func (p *Pdf) ConvertTo(format string) ([]byte, error) {
+func (p *Pdf) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/pkg/files/file_factory.go
+++ b/pkg/files/file_factory.go
@@ -1,0 +1,23 @@
+package files
+
+import "fmt"
+
+type FileFactory interface {
+	NewFile(string) (File, error)
+}
+
+const (
+	Img = "image"
+	Doc = "document"
+)
+
+func BuildFactory(f string) (FileFactory, error) {
+	switch f {
+	case Img:
+		return new(ImageFactory), nil
+	case Doc:
+		return new(DocumentFactory), nil
+	default:
+		return nil, fmt.Errorf("factory with id %s not recognized", f)
+	}
+}

--- a/pkg/files/file_factory.go
+++ b/pkg/files/file_factory.go
@@ -2,20 +2,28 @@ package files
 
 import "fmt"
 
+// FileFactory interface is responsible for defining how a FileFactory behaves.
+// It defines a NewFile method that returns an entity
+// that implements the File interface.
 type FileFactory interface {
 	NewFile(string) (File, error)
 }
 
 const (
 	Img = "image"
-	Doc = "document"
+	// Application is provide because the type from the document's mimetype
+	// is defined as application, not document. Both are supported.
+	Application = "application"
+	Doc         = "document"
 )
 
+// BuildFactory is a function responsible to return a FileFactory,
+// given a supported and valid file type, otherwise, it will error out.
 func BuildFactory(f string) (FileFactory, error) {
 	switch f {
 	case Img:
 		return new(ImageFactory), nil
-	case Doc:
+	case Doc, Application:
 		return new(DocumentFactory), nil
 	default:
 		return nil, fmt.Errorf("factory with id %s not recognized", f)

--- a/pkg/files/file_factory_test.go
+++ b/pkg/files/file_factory_test.go
@@ -1,0 +1,39 @@
+package files
+
+import (
+	"testing"
+
+	"github.com/danvergara/morphos/pkg/files/documents"
+	"github.com/danvergara/morphos/pkg/files/images"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageFactory(t *testing.T) {
+	imgF, err := BuildFactory(Img)
+	require.NoError(t, err)
+
+	imageFile, err := imgF.NewFile(images.PNG)
+	require.NoError(t, err)
+
+	png, ok := imageFile.(Image)
+	if !ok {
+		t.Fatal("struct assertion has failed")
+	}
+
+	t.Logf("Png image has type %s", png.ImageType())
+}
+
+func TestDocumentFactory(t *testing.T) {
+	docF, err := BuildFactory(Doc)
+	require.NoError(t, err)
+
+	docFile, err := docF.NewFile(documents.PDF)
+	require.NoError(t, err)
+
+	pdf, ok := docFile.(Document)
+	if !ok {
+		t.Fatal("struct assertion has failed")
+	}
+
+	t.Logf("PDF document has type %s", pdf.DocumentType())
+}

--- a/pkg/files/file_factory_test.go
+++ b/pkg/files/file_factory_test.go
@@ -3,9 +3,10 @@ package files
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/danvergara/morphos/pkg/files/documents"
 	"github.com/danvergara/morphos/pkg/files/images"
-	"github.com/stretchr/testify/require"
 )
 
 func TestImageFactory(t *testing.T) {

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -1,0 +1,6 @@
+package files
+
+type File interface {
+	SupportedFormats() map[string]string
+	ConvertTo(string) ([]byte, error)
+}

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -1,5 +1,9 @@
 package files
 
+// File interface is the main interface of the package,
+// that defines what a file is in this context.
+// It's moslty responsible to say other entitites what formats it can be converted to
+// and provides a method to convert the current file given a target format, if supported.
 type File interface {
 	SupportedFormats() map[string][]string
 	ConvertTo(string, []byte) ([]byte, error)

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -1,6 +1,6 @@
 package files
 
 type File interface {
-	SupportedFormats() map[string]string
-	ConvertTo(string) ([]byte, error)
+	SupportedFormats() map[string][]string
+	ConvertTo(string, []byte) ([]byte, error)
 }

--- a/pkg/files/image_factory.go
+++ b/pkg/files/image_factory.go
@@ -14,6 +14,14 @@ func (i *ImageFactory) NewFile(f string) (File, error) {
 		return new(images.Png), nil
 	case images.JPEG:
 		return new(images.Jpeg), nil
+	case images.GIF:
+		return new(images.Gif), nil
+	case images.WEBP:
+		return new(images.Webp), nil
+	case images.TIFF:
+		return new(images.Tiff), nil
+	case images.BMP:
+		return new(images.Bmp), nil
 	default:
 		return nil, fmt.Errorf("file of type %s not recognized\n", f)
 	}

--- a/pkg/files/image_factory.go
+++ b/pkg/files/image_factory.go
@@ -1,0 +1,20 @@
+package files
+
+import (
+	"fmt"
+
+	"github.com/danvergara/morphos/pkg/files/images"
+)
+
+type ImageFactory struct{}
+
+func (i *ImageFactory) NewFile(f string) (File, error) {
+	switch f {
+	case images.PNG:
+		return new(images.Png), nil
+	case images.JPEG:
+		return new(images.Jpeg), nil
+	default:
+		return nil, fmt.Errorf("file of type %s not recognized\n", f)
+	}
+}

--- a/pkg/files/image_factory.go
+++ b/pkg/files/image_factory.go
@@ -6,8 +6,12 @@ import (
 	"github.com/danvergara/morphos/pkg/files/images"
 )
 
+// ImageFactory implements the FileFactory interface.
 type ImageFactory struct{}
 
+// NewFile method returns an object that implements the File interface,
+// given an image format as input.
+// If not supported, it will error out.
 func (i *ImageFactory) NewFile(f string) (File, error) {
 	switch f {
 	case images.PNG:

--- a/pkg/files/images.go
+++ b/pkg/files/images.go
@@ -1,5 +1,7 @@
 package files
 
+// Image interface is the one that defines what an images is
+// in this context. It's responsible to return kind of the underlying image.
 type Image interface {
 	ImageType() string
 }

--- a/pkg/files/images.go
+++ b/pkg/files/images.go
@@ -1,0 +1,5 @@
+package files
+
+type Image interface {
+	ImageType() string
+}

--- a/pkg/files/images/bmp.go
+++ b/pkg/files/images/bmp.go
@@ -3,39 +3,39 @@ package images
 import (
 	"bytes"
 	"fmt"
-	"image/png"
+
+	"golang.org/x/image/bmp"
 )
 
-type Png struct{}
+type Bmp struct{}
 
-func (p *Png) SupportedFormats() map[string][]string {
+func (b *Bmp) SupportedFormats() map[string][]string {
 	return map[string][]string{
 		"Image": {
 			JPG,
+			PNG,
 			GIF,
-			WEBP,
 			TIFF,
-			BMP,
+			WEBP,
 		},
 	}
 }
 
-func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
+func (b *Bmp) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	var result []byte
 
-	img, err := png.Decode(bytes.NewReader(fileBytes))
+	img, err := bmp.Decode(bytes.NewReader(fileBytes))
 	if err != nil {
 		return nil, err
 	}
-
 	switch format {
 	case JPEG, JPG:
 		result, err = toJPG(img)
 		if err != nil {
 			return nil, err
 		}
-	case GIF:
-		result, err = toGIF(img)
+	case PNG:
+		result, err = toPNG(img)
 		if err != nil {
 			return nil, err
 		}
@@ -44,13 +44,13 @@ func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-	case TIFF:
-		result, err = toTIFF(img)
+	case GIF:
+		result, err = toGIF(img)
 		if err != nil {
 			return nil, err
 		}
-	case BMP:
-		result, err = toBMP(img)
+	case TIFF:
+		result, err = toTIFF(img)
 		if err != nil {
 			return nil, err
 		}
@@ -61,6 +61,6 @@ func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	return result, nil
 }
 
-func (p *Png) ImageType() string {
-	return PNG
+func (b *Bmp) ImageType() string {
+	return BMP
 }

--- a/pkg/files/images/bmp.go
+++ b/pkg/files/images/bmp.go
@@ -7,8 +7,11 @@ import (
 	"golang.org/x/image/bmp"
 )
 
+// Bmp struct implements the File and Image interface from the files pkg.
 type Bmp struct{}
 
+// SupportedFormats returns a map with a slice of supported files.
+// Every key of the map represents a kind of a file.
 func (b *Bmp) SupportedFormats() map[string][]string {
 	return map[string][]string{
 		"Image": {
@@ -21,6 +24,8 @@ func (b *Bmp) SupportedFormats() map[string][]string {
 	}
 }
 
+// ConvertTo method converts a given file to a target format.
+// This method returns a file in form of a slice of bytes.
 func (b *Bmp) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	var result []byte
 
@@ -61,6 +66,8 @@ func (b *Bmp) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	return result, nil
 }
 
+// ImageType returns the file format of the current image.
+// This method implements the Image interface.
 func (b *Bmp) ImageType() string {
 	return BMP
 }

--- a/pkg/files/images/gif.go
+++ b/pkg/files/images/gif.go
@@ -3,16 +3,16 @@ package images
 import (
 	"bytes"
 	"fmt"
-	"image/png"
+	"image/gif"
 )
 
-type Png struct{}
+type Gif struct{}
 
-func (p *Png) SupportedFormats() map[string][]string {
+func (g *Gif) SupportedFormats() map[string][]string {
 	return map[string][]string{
 		"Image": {
 			JPG,
-			GIF,
+			PNG,
 			WEBP,
 			TIFF,
 			BMP,
@@ -20,10 +20,10 @@ func (p *Png) SupportedFormats() map[string][]string {
 	}
 }
 
-func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
+func (g *Gif) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	var result []byte
 
-	img, err := png.Decode(bytes.NewReader(fileBytes))
+	img, err := gif.Decode(bytes.NewReader(fileBytes))
 	if err != nil {
 		return nil, err
 	}
@@ -34,8 +34,8 @@ func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-	case GIF:
-		result, err = toGIF(img)
+	case PNG:
+		result, err = toPNG(img)
 		if err != nil {
 			return nil, err
 		}
@@ -61,6 +61,6 @@ func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	return result, nil
 }
 
-func (p *Png) ImageType() string {
-	return PNG
+func (g *Gif) ImageType() string {
+	return GIF
 }

--- a/pkg/files/images/gif.go
+++ b/pkg/files/images/gif.go
@@ -6,8 +6,11 @@ import (
 	"image/gif"
 )
 
+// Gif struct implements the File and Image interface from the files pkg.
 type Gif struct{}
 
+// SupportedFormats returns a map with a slice of supported files.
+// Every key of the map represents the kind of a file.
 func (g *Gif) SupportedFormats() map[string][]string {
 	return map[string][]string{
 		"Image": {
@@ -20,6 +23,8 @@ func (g *Gif) SupportedFormats() map[string][]string {
 	}
 }
 
+// ConvertTo method converts a given file to a target format.
+// This method returns a file in form of a slice of bytes.
 func (g *Gif) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	var result []byte
 
@@ -61,6 +66,8 @@ func (g *Gif) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	return result, nil
 }
 
+// ImageType returns the file format of the current image.
+// This method implements the Image interface.
 func (g *Gif) ImageType() string {
 	return GIF
 }

--- a/pkg/files/images/images.go
+++ b/pkg/files/images/images.go
@@ -2,7 +2,6 @@ package images
 
 import (
 	"bytes"
-	"fmt"
 	"image"
 	"image/gif"
 	"image/jpeg"
@@ -12,7 +11,6 @@ import (
 	"github.com/chai2010/webp"
 	"golang.org/x/image/bmp"
 	"golang.org/x/image/tiff"
-	webpx "golang.org/x/image/webp"
 )
 
 const (
@@ -26,100 +24,6 @@ const (
 
 	imageMimeType = "image/"
 )
-
-// FileFormat is the file format representation meant to be shown in the
-// form template as an option.
-type FileFormat struct {
-	// Name of the file format to be shown in the option tag and as option value.
-	Name string
-}
-
-// ConverImage returns a image converted as an array of bytes,
-// if somethings wrong happens, the functions will error out.
-// The functions receives the format from to be converted,
-// the file format to be converted to and the image to be converted.
-func ConverImage(from, to string, imageBytes []byte) ([]byte, error) {
-	var (
-		img    image.Image
-		result []byte
-		err    error
-	)
-
-	to = ParseMimeType(to)
-	from = ParseMimeType(from)
-
-	switch from {
-	case PNG:
-		img, err = png.Decode(bytes.NewReader(imageBytes))
-		if err != nil {
-			return nil, err
-		}
-	case JPEG, JPG:
-		img, err = jpeg.Decode(bytes.NewReader(imageBytes))
-		if err != nil {
-			return nil, err
-		}
-	case GIF:
-		img, err = gif.Decode(bytes.NewReader(imageBytes))
-		if err != nil {
-			return nil, err
-		}
-	case WEBP:
-		img, err = webpx.Decode(bytes.NewReader(imageBytes))
-		if err != nil {
-			return nil, err
-		}
-	case TIFF:
-		img, err = tiff.Decode(bytes.NewReader(imageBytes))
-		if err != nil {
-			return nil, err
-		}
-	case BMP:
-		img, err = bmp.Decode(bytes.NewReader(imageBytes))
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("file format %s not supported", from)
-	}
-
-	switch to {
-	case PNG:
-		result, err = toPNG(img)
-		if err != nil {
-			return nil, err
-		}
-	case JPEG, JPG:
-		result, err = toJPG(img)
-		if err != nil {
-			return nil, err
-		}
-	case GIF:
-		result, err = toGIF(img)
-		if err != nil {
-			return nil, err
-		}
-	case WEBP:
-		result, err = toWEBP(img)
-		if err != nil {
-			return nil, err
-		}
-	case TIFF:
-		result, err = toTIFF(img)
-		if err != nil {
-			return nil, err
-		}
-	case BMP:
-		result, err = toBMP(img)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, fmt.Errorf("file format to conver to %s not supported", to)
-	}
-
-	return result, nil
-}
 
 func toPNG(img image.Image) ([]byte, error) {
 	buf := new(bytes.Buffer)
@@ -184,76 +88,6 @@ func toBMP(img image.Image) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
-}
-
-func FileFormatsToConvert(to string) map[string][]FileFormat {
-	formats := make(map[string][]FileFormat)
-
-	to = ParseMimeType(to)
-
-	switch to {
-	case JPEG, JPG:
-		formats = map[string][]FileFormat{
-			"Formats": {
-				{Name: PNG},
-				{Name: GIF},
-				{Name: WEBP},
-				{Name: TIFF},
-				{Name: BMP},
-			},
-		}
-	case PNG:
-		formats = map[string][]FileFormat{
-			"Formats": {
-				{Name: JPG},
-				{Name: GIF},
-				{Name: WEBP},
-				{Name: TIFF},
-				{Name: BMP},
-			},
-		}
-	case GIF:
-		formats = map[string][]FileFormat{
-			"Formats": {
-				{Name: JPG},
-				{Name: PNG},
-				{Name: WEBP},
-				{Name: TIFF},
-				{Name: BMP},
-			},
-		}
-	case WEBP:
-		formats = map[string][]FileFormat{
-			"Formats": {
-				{Name: JPG},
-				{Name: PNG},
-				{Name: GIF},
-				{Name: TIFF},
-				{Name: BMP},
-			},
-		}
-	case TIFF:
-		formats = map[string][]FileFormat{
-			"Formats": {
-				{Name: JPG},
-				{Name: PNG},
-				{Name: GIF},
-				{Name: WEBP},
-				{Name: BMP},
-			},
-		}
-	case BMP:
-		formats = map[string][]FileFormat{
-			"Formats": {
-				{Name: JPG},
-				{Name: PNG},
-				{Name: GIF},
-				{Name: WEBP},
-				{Name: TIFF},
-			},
-		}
-	}
-	return formats
 }
 
 func ParseMimeType(mimetype string) string {

--- a/pkg/files/images/images_test.go
+++ b/pkg/files/images/images_test.go
@@ -184,6 +184,7 @@ func TestConvertImage(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/files/images/jpeg.go
+++ b/pkg/files/images/jpeg.go
@@ -1,15 +1,64 @@
 package images
 
-import "errors"
+import (
+	"bytes"
+	"fmt"
+	"image/jpeg"
+)
 
 type Jpeg struct{}
 
-func (p *Jpeg) SupportedFormats() map[string]string {
-	return make(map[string]string)
+func (p *Jpeg) SupportedFormats() map[string][]string {
+	return map[string][]string{
+		"Image": {
+			PNG,
+			GIF,
+			WEBP,
+			TIFF,
+			BMP,
+		},
+	}
 }
 
-func (p *Jpeg) ConvertTo(format string) ([]byte, error) {
-	return nil, errors.New("not implemented")
+func (p *Jpeg) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
+	var result []byte
+
+	img, err := jpeg.Decode(bytes.NewReader(fileBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	switch format {
+	case PNG:
+		result, err = toPNG(img)
+		if err != nil {
+			return nil, err
+		}
+	case GIF:
+		result, err = toGIF(img)
+		if err != nil {
+			return nil, err
+		}
+	case WEBP:
+		result, err = toWEBP(img)
+		if err != nil {
+			return nil, err
+		}
+	case TIFF:
+		result, err = toTIFF(img)
+		if err != nil {
+			return nil, err
+		}
+	case BMP:
+		result, err = toBMP(img)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("file format to conver to %s not supported", format)
+	}
+
+	return result, nil
 }
 
 func (p *Jpeg) ImageType() string {

--- a/pkg/files/images/jpeg.go
+++ b/pkg/files/images/jpeg.go
@@ -1,0 +1,17 @@
+package images
+
+import "errors"
+
+type Jpeg struct{}
+
+func (p *Jpeg) SupportedFormats() map[string]string {
+	return make(map[string]string)
+}
+
+func (p *Jpeg) ConvertTo(format string) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *Jpeg) ImageType() string {
+	return JPEG
+}

--- a/pkg/files/images/jpeg.go
+++ b/pkg/files/images/jpeg.go
@@ -6,8 +6,11 @@ import (
 	"image/jpeg"
 )
 
+// Jpeg struct implements the File and Image interface from the files pkg.
 type Jpeg struct{}
 
+// SupportedFormats returns a map with a slice of supported files.
+// Every key of the map represents a kind of a file.
 func (p *Jpeg) SupportedFormats() map[string][]string {
 	return map[string][]string{
 		"Image": {
@@ -20,6 +23,8 @@ func (p *Jpeg) SupportedFormats() map[string][]string {
 	}
 }
 
+// ConvertTo method converts a given file to a target format.
+// This method returns a file in form of a slice of bytes.
 func (p *Jpeg) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	var result []byte
 
@@ -61,6 +66,8 @@ func (p *Jpeg) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	return result, nil
 }
 
+// ImageType returns the file format of the current image.
+// This method implements the Image interface.
 func (p *Jpeg) ImageType() string {
 	return JPEG
 }

--- a/pkg/files/images/png.go
+++ b/pkg/files/images/png.go
@@ -6,8 +6,11 @@ import (
 	"image/png"
 )
 
+// Png struct implements the File and Image interface from the files pkg.
 type Png struct{}
 
+// SupportedFormats returns a map with a slice of supported files.
+// Every key of the map represents the kind of a file.
 func (p *Png) SupportedFormats() map[string][]string {
 	return map[string][]string{
 		"Image": {
@@ -20,6 +23,8 @@ func (p *Png) SupportedFormats() map[string][]string {
 	}
 }
 
+// ConvertTo method converts a given file to a target format.
+// This method returns a file in form of a slice of bytes.
 func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	var result []byte
 
@@ -61,6 +66,8 @@ func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	return result, nil
 }
 
+// ImageType returns the file format of the current image.
+// This method implements the Image interface.
 func (p *Png) ImageType() string {
 	return PNG
 }

--- a/pkg/files/images/png.go
+++ b/pkg/files/images/png.go
@@ -1,0 +1,17 @@
+package images
+
+import "errors"
+
+type Png struct{}
+
+func (p *Png) SupportedFormats() map[string]string {
+	return make(map[string]string)
+}
+
+func (p *Png) ConvertTo(format string) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *Png) ImageType() string {
+	return PNG
+}

--- a/pkg/files/images/tiff.go
+++ b/pkg/files/images/tiff.go
@@ -7,8 +7,11 @@ import (
 	"golang.org/x/image/tiff"
 )
 
+// Tiff struct implements the File and Image interface from the files pkg.
 type Tiff struct{}
 
+// SupportedFormats method returns a map with a slice of supported files.
+// Every key of the map represents the kind of a file.
 func (t *Tiff) SupportedFormats() map[string][]string {
 	return map[string][]string{
 		"Image": {
@@ -21,6 +24,8 @@ func (t *Tiff) SupportedFormats() map[string][]string {
 	}
 }
 
+// ConvertTo method converts a given file to a target format.
+// This method returns a file in form of a slice of bytes.
 func (t *Tiff) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	var result []byte
 
@@ -62,6 +67,8 @@ func (t *Tiff) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	return result, nil
 }
 
+// ImageType returns the file format of the current image.
+// This method implements the Image interface.
 func (t *Tiff) ImageType() string {
 	return TIFF
 }

--- a/pkg/files/images/tiff.go
+++ b/pkg/files/images/tiff.go
@@ -3,27 +3,28 @@ package images
 import (
 	"bytes"
 	"fmt"
-	"image/png"
+
+	"golang.org/x/image/tiff"
 )
 
-type Png struct{}
+type Tiff struct{}
 
-func (p *Png) SupportedFormats() map[string][]string {
+func (t *Tiff) SupportedFormats() map[string][]string {
 	return map[string][]string{
 		"Image": {
 			JPG,
+			PNG,
 			GIF,
 			WEBP,
-			TIFF,
 			BMP,
 		},
 	}
 }
 
-func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
+func (t *Tiff) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	var result []byte
 
-	img, err := png.Decode(bytes.NewReader(fileBytes))
+	img, err := tiff.Decode(bytes.NewReader(fileBytes))
 	if err != nil {
 		return nil, err
 	}
@@ -34,8 +35,8 @@ func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-	case GIF:
-		result, err = toGIF(img)
+	case PNG:
+		result, err = toPNG(img)
 		if err != nil {
 			return nil, err
 		}
@@ -44,8 +45,8 @@ func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-	case TIFF:
-		result, err = toTIFF(img)
+	case GIF:
+		result, err = toGIF(img)
 		if err != nil {
 			return nil, err
 		}
@@ -61,6 +62,6 @@ func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	return result, nil
 }
 
-func (p *Png) ImageType() string {
-	return PNG
+func (t *Tiff) ImageType() string {
+	return TIFF
 }

--- a/pkg/files/images/webp.go
+++ b/pkg/files/images/webp.go
@@ -3,27 +3,28 @@ package images
 import (
 	"bytes"
 	"fmt"
-	"image/png"
+
+	"golang.org/x/image/webp"
 )
 
-type Png struct{}
+type Webp struct{}
 
-func (p *Png) SupportedFormats() map[string][]string {
+func (w *Webp) SupportedFormats() map[string][]string {
 	return map[string][]string{
 		"Image": {
 			JPG,
+			PNG,
 			GIF,
-			WEBP,
 			TIFF,
 			BMP,
 		},
 	}
 }
 
-func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
+func (w *Webp) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	var result []byte
 
-	img, err := png.Decode(bytes.NewReader(fileBytes))
+	img, err := webp.Decode(bytes.NewReader(fileBytes))
 	if err != nil {
 		return nil, err
 	}
@@ -34,13 +35,13 @@ func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-	case GIF:
-		result, err = toGIF(img)
+	case PNG:
+		result, err = toPNG(img)
 		if err != nil {
 			return nil, err
 		}
-	case WEBP:
-		result, err = toWEBP(img)
+	case GIF:
+		result, err = toGIF(img)
 		if err != nil {
 			return nil, err
 		}
@@ -61,6 +62,6 @@ func (p *Png) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	return result, nil
 }
 
-func (p *Png) ImageType() string {
-	return PNG
+func (w *Webp) ImageType() string {
+	return WEBP
 }

--- a/pkg/files/images/webp.go
+++ b/pkg/files/images/webp.go
@@ -7,8 +7,11 @@ import (
 	"golang.org/x/image/webp"
 )
 
+// Webp struct implements the File and Image interface from the files pkg.
 type Webp struct{}
 
+// SupportedFormats returns a map with a slice of supported files.
+// Every key of the map represents the kind of a file.
 func (w *Webp) SupportedFormats() map[string][]string {
 	return map[string][]string{
 		"Image": {
@@ -21,6 +24,8 @@ func (w *Webp) SupportedFormats() map[string][]string {
 	}
 }
 
+// ConvertTo method converts a given file to a target format.
+// This method returns a file in form of a slice of bytes.
 func (w *Webp) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	var result []byte
 
@@ -62,6 +67,8 @@ func (w *Webp) ConvertTo(format string, fileBytes []byte) ([]byte, error) {
 	return result, nil
 }
 
+// ImageType method returns the file format of the current image.
+// This method implements the Image interface.
 func (w *Webp) ImageType() string {
 	return WEBP
 }

--- a/pkg/files/mimetypes.go
+++ b/pkg/files/mimetypes.go
@@ -1,0 +1,21 @@
+package files
+
+import (
+	"fmt"
+	"strings"
+)
+
+// TypeAndSupType returns a the type and the sub-type of a
+// given mimetype.
+// e.g. image/png
+// type: image
+// subtype: png
+func TypeAndSupType(mimetype string) (string, string, error) {
+	types := strings.Split(mimetype, "/")
+
+	if len(types) != 2 {
+		return "", "", fmt.Errorf("%s not valid", mimetype)
+	}
+
+	return types[0], types[1], nil
+}

--- a/pkg/files/mimetypes_test.go
+++ b/pkg/files/mimetypes_test.go
@@ -1,0 +1,35 @@
+package files
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTypeAndSupType(t *testing.T) {
+	type expected struct {
+		fileType string
+		subType  string
+		hasErr   bool
+	}
+
+	var tests = []struct {
+		name     string
+		mimetype string
+		expected expected
+	}{}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fileType, subType, err := TypeAndSupType(tc.mimetype)
+			if tc.expected.hasErr {
+				require.Error(t, err)
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected.fileType, fileType)
+			require.Equal(t, tc.expected.subType, subType)
+		})
+	}
+}

--- a/templates/partials/form.tmpl
+++ b/templates/partials/form.tmpl
@@ -24,10 +24,13 @@
         <div class="col-sm">
           <label for="input-format" class="form-label">Formats to convert</label>
           <select id="input-format" class="form-select" name="input_format">
-            <option selected>...</option>
             {{ block "format-elements" . }}
-              {{ range $element := .Formats }}
-                <option value="{{ $element.Name }}">{{ $element.Name }}</option>
+              {{ range $family, $formats := . }}
+                <optgroup label="{{ $family }}">
+                {{ range $element := $formats }}
+                  <option value="{{ $element }}">{{ $element }}</option>
+                {{ end }}
+                </optgroup>
               {{ end }}
             {{ end}}
           </select>


### PR DESCRIPTION
## Description

I'm about to add features to convert files to documents and vice versa, so I'll need to add some design patterns to come up concrete types based off their family types.

I made a diagram to depict how this new change works:
![File_Converter_Abstract_Factory](https://github.com/danvergara/morphos/assets/12239167/30d3bf60-e7c9-4f6b-961f-c70b7a5f3108)

To put it another way, this change aims to provide a way to select between different file kinds, such as images, documents, videos, etc.
![Screenshot from 2023-12-10 16-50-09](https://github.com/danvergara/morphos/assets/12239167/62613e65-6986-49d3-8cf5-33483723be78)

Today, there's only support for images. Document support will be added in upcoming Pull Requests.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I've added tests to validate the new behavior.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings