### PR TITLE
Add multi stage to the dockerfile with ubuntu as last stage to get the same env without non necessary deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,54 @@
-FROM ubuntu:22.04 AS base
+FROM ubuntu:22.04 AS build
 
-ARG GO_VERSION
+ARG GO_VERSION TARGETOS TARGETARCH
+
 ENV GO_VERSION=${GO_VERSION}
-
-RUN apt-get update
-RUN apt-get install -y wget git gcc
-
-RUN wget -P /tmp "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz"
-
-RUN tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
-RUN rm "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
-
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:strukturag/libde265 && \
+    add-apt-repository ppa:strukturag/libheif && \
+    apt-get install -y --no-install-recommends cmake \
+      wget \
+      git \
+      gcc \
+      make \
+      pkg-config \
+      x265 \
+      libx265-dev \
+      libde265-dev \
+      libjpeg-dev \
+      libtool \
+      zlib1g-dev \
+      libaom-dev \
+      libheif1 \
+      libheif-dev && \
+      apt-get autoremove -y && \
+      apt-get purge -y --auto-remove && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN wget --no-check-certificate -P /tmp "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" && \
+    tar -C /usr/local -xzf "/tmp/go${GO_VERSION}.linux-amd64.tar.gz" && \
+    rm "/tmp/go${GO_VERSION}.linux-amd64.tar.gz"
+
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
-WORKDIR $GOPATH
+WORKDIR /build
 
-FROM base AS builder
+COPY go.* ./
+RUN go mod download
+
+COPY . .
+
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags='-s -w' -trimpath -o /app/morphos .
+
+FROM ubuntu:22.04
+
+WORKDIR /app
+
+COPY --from=build /app/morphos .
 
 RUN apt-get update && \
     apt-get install -y software-properties-common && \
@@ -35,19 +66,10 @@ RUN apt-get update && \
       libaom-dev \
       libheif1 \
       libheif-dev && \
-      apt-get clean && \
+      apt-get autoremove -y && \
+      apt-get purge -y --auto-remove && \
     rm -rf /var/lib/apt/lists/*
 
-ARG TARGETOS
-ARG TARGETARCH
-
-WORKDIR /build
-
-COPY go.* ./
-RUN go mod download
-
-COPY . .
-
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags='-s -w' -trimpath -o /app/morphos .
+EXPOSE 8080
 
 ENTRYPOINT ["/app/morphos"]


### PR DESCRIPTION
# Optimize Container image size

## Description

Add multi-stage to the Dockerfile with Ubuntu as last stage without non-necessary dependencies (go, git, etc.) just having the dependencies required by `libheif` and `go-avif` and the final binary. Before the change the image size was 1.16 GB and now it is 520 MB.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I built the image locally many times and used [dive](https://github.com/wagoodman/dive) to dive deeper into the image file system to see potential improvements.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
