### PR TITLE
Only push image on tags and releases

### DIFF
--- a/.github/workflows/deploy_image.yml
+++ b/.github/workflows/deploy_image.yml
@@ -2,11 +2,8 @@ name: Deploy Morphos Server Container Image
 
 on:
   push:
-    branches:
-      - main
-
-env:
-  GO_VERSION: 1.21.5
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+' # Only build on tag with semantic versioning format
 
 jobs:
   push_morphos_image:
@@ -18,6 +15,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up QEMU
+      - name: Set release tag env variable
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -33,4 +32,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/${{ github.actor }}/morphos-server:latest
+          tags: ghcr.io/${{ github.actor }}/morphos-server:latest, ghcr.io/${{ github.actor }}/morphos-server:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/deploy_image.yml
+++ b/.github/workflows/deploy_image.yml
@@ -33,3 +33,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ github.actor }}/morphos-server:latest, ghcr.io/${{ github.actor }}/morphos-server:${{ env.RELEASE_VERSION }}
+      - name: Release
+        uses: softprops/action-gh-release@v1


### PR DESCRIPTION
# Only push image on tags and releases

## Description

This PR restricts when to push the image to container registry, doing so on merge events onto the main branch could be risky for users.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
