### PR TITLE
Add idiomatic error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 HTMX_VERSION=1.9.6
+RESPONSE_TARGETS_VERSION=1.9.11
 BOOTSTRAP_VERSION=5.3.2
 GO_VERSION=1.21.5
 
@@ -15,7 +16,7 @@ download-htmx:
 .PHONY: download-htmx-resp-targ
 ## download-htmx-resp-targ: Downloads the HTMX response target extension
 download-htmx-resp-targ:
-	curl -o static/response-targets.js https://unpkg.com/htmx.org@${HTMX_VERSION}/dist/ext/response-targets.js
+	curl -o static/response-targets.js https://unpkg.com/htmx.org@${RESPONSE_TARGETS_VERSION}/dist/ext/response-targets.js
 
 .PHONY: download-bootstrap
 ## download-bootstrap: Downloads Bootstrap minified css/js file

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ run:
 download-htmx:
 	curl -o static/htmx.min.js https://unpkg.com/htmx.org@${HTMX_VERSION}/dist/htmx.min.js
 
+.PHONY: download-htmx-resp-targ
+## download-htmx-resp-targ: Downloads the HTMX response target extension
+download-htmx-resp-targ:
+	curl -o static/response-targets.js https://unpkg.com/htmx.org@${HTMX_VERSION}/dist/ext/response-targets.js
+
 .PHONY: download-bootstrap
 ## download-bootstrap: Downloads Bootstrap minified css/js file
 download-bootstrap:

--- a/main.go
+++ b/main.go
@@ -62,14 +62,14 @@ func index(w http.ResponseWriter, _ *http.Request) {
 	tmpl, err := template.ParseFS(templatesHTML, tmpls...)
 	if err != nil {
 		log.Printf("error ocurred parsing templates: %v", err)
-		renderError(w, "INTERNAL_ERROR", http.StatusInternalServerError)
+		renderError(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
 	err = tmpl.ExecuteTemplate(w, "base", nil)
 	if err != nil {
 		log.Printf("error ocurred executing template: %v", err)
-		renderError(w, "INTERNAL_ERROR", http.StatusInternalServerError)
+		renderError(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 }
@@ -86,7 +86,7 @@ func handleUploadFile(w http.ResponseWriter, r *http.Request) {
 	file, fileHeader, err := r.FormFile(uploadFileFormField)
 	if err != nil {
 		log.Printf("error ocurred getting file from form: %v", err)
-		renderError(w, "INVALID_FILE", http.StatusBadRequest)
+		renderError(w, "invalid file", http.StatusBadRequest)
 		return
 	}
 	defer file.Close()
@@ -94,7 +94,7 @@ func handleUploadFile(w http.ResponseWriter, r *http.Request) {
 	fileBytes, err := io.ReadAll(file)
 	if err != nil {
 		log.Printf("error ocurred reading file: %v", err)
-		renderError(w, "INVALID_FILE", http.StatusBadRequest)
+		renderError(w, "invalid file", http.StatusBadRequest)
 		return
 	}
 
@@ -105,21 +105,21 @@ func handleUploadFile(w http.ResponseWriter, r *http.Request) {
 	fileType, subType, err := files.TypeAndSupType(detectedFileType.String())
 	if err != nil {
 		log.Printf("error occurred getting type and subtype from mimetype: %v", err)
-		renderError(w, "INVALID_FILE", http.StatusBadRequest)
+		renderError(w, "invalid file", http.StatusBadRequest)
 		return
 	}
 
 	fileFactory, err := files.BuildFactory(fileType, fileHeader.Filename)
 	if err != nil {
 		log.Printf("error occurred while getting a file factory: %v", err)
-		renderError(w, "INVALID_FILE", http.StatusBadRequest)
+		renderError(w, "invalid file", http.StatusBadRequest)
 		return
 	}
 
 	f, err := fileFactory.NewFile(subType)
 	if err != nil {
 		log.Printf("error occurred getting the file object: %v", err)
-		renderError(w, "INVALID_FILE", http.StatusBadRequest)
+		renderError(w, "invalid file", http.StatusBadRequest)
 		return
 	}
 
@@ -131,7 +131,7 @@ func handleUploadFile(w http.ResponseWriter, r *http.Request) {
 	)
 	if err != nil {
 		log.Printf("error ocurred while converting image %v", err)
-		renderError(w, "INTERNAL_ERROR", http.StatusInternalServerError)
+		renderError(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
@@ -163,7 +163,7 @@ func handleUploadFile(w http.ResponseWriter, r *http.Request) {
 	tmpl, err := template.ParseFS(templatesHTML, tmpls...)
 	if err != nil {
 		log.Printf("error occurred parsing template files: %v", err)
-		renderError(w, "INTERNAL_ERROR", http.StatusInternalServerError)
+		renderError(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
@@ -172,7 +172,7 @@ func handleUploadFile(w http.ResponseWriter, r *http.Request) {
 	convertedFileType, _, err := files.TypeAndSupType(convertedFileMimeType.String())
 	if err != nil {
 		log.Printf("error occurred getting the file type of the result file: %v", err)
-		renderError(w, "INTERNAL_ERROR", http.StatusInternalServerError)
+		renderError(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
@@ -183,7 +183,7 @@ func handleUploadFile(w http.ResponseWriter, r *http.Request) {
 	)
 	if err != nil {
 		log.Printf("error occurred executing template files: %v", err)
-		renderError(w, "INTERNAL_ERROR", http.StatusInternalServerError)
+		renderError(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 }
@@ -192,15 +192,15 @@ func handleFileFormat(w http.ResponseWriter, r *http.Request) {
 
 	file, _, err := r.FormFile(uploadFileFormField)
 	if err != nil {
-		log.Printf("error ocurred getting file from form: %v", err)
-		renderError(w, "INVALID_FILE", http.StatusBadRequest)
+		log.Printf("error ocurred while getting file from form: %v", err)
+		renderError(w, "invalid file", http.StatusBadRequest)
 		return
 	}
 
 	fileBytes, err := io.ReadAll(file)
 	if err != nil {
-		log.Printf("error occurred executing template files: %v", err)
-		renderError(w, "INVALID_FILE", http.StatusBadRequest)
+		log.Printf("error occurred while executing template files: %v", err)
+		renderError(w, "invalid file", http.StatusBadRequest)
 		return
 	}
 
@@ -213,28 +213,28 @@ func handleFileFormat(w http.ResponseWriter, r *http.Request) {
 	fileType, subType, err := files.TypeAndSupType(detectedFileType.String())
 	if err != nil {
 		log.Printf("error occurred getting type and subtype from mimetype: %v", err)
-		renderError(w, "INVALID_FILE", http.StatusBadRequest)
+		renderError(w, "invalid file format", http.StatusBadRequest)
 		return
 	}
 
 	fileFactory, err := files.BuildFactory(fileType, "")
 	if err != nil {
 		log.Printf("error occurred while getting a file factory: %v", err)
-		renderError(w, "INVALID_FILE", http.StatusBadRequest)
+		renderError(w, "invalid file", http.StatusBadRequest)
 		return
 	}
 
 	f, err := fileFactory.NewFile(subType)
 	if err != nil {
 		log.Printf("error occurred getting the file object: %v", err)
-		renderError(w, "INTERNAL_ERROR", http.StatusInternalServerError)
+		renderError(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
 	tmpl, err := template.ParseFS(templatesHTML, templates...)
 	if err = tmpl.ExecuteTemplate(w, "format-elements", f.SupportedFormats()); err != nil {
 		log.Printf("error occurred parsing template files: %v", err)
-		renderError(w, "INTERNAL_ERROR", http.StatusInternalServerError)
+		renderError(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 }
@@ -250,13 +250,13 @@ func handleModal(w http.ResponseWriter, r *http.Request) {
 	tmpl, err := template.ParseFS(templatesHTML, tmpls...)
 	if err != nil {
 		log.Printf("error occurred parsing template files: %v", err)
-		renderError(w, "INTERNAL_ERROR", http.StatusInternalServerError)
+		renderError(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
 	if err = tmpl.ExecuteTemplate(w, "content", ConvertedFile{Filename: filename, FileType: filetype}); err != nil {
 		log.Printf("error occurred executing template files: %v", err)
-		renderError(w, "INTERNAL_ERROR", http.StatusInternalServerError)
+		renderError(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 }
@@ -288,7 +288,8 @@ func main() {
 
 func renderError(w http.ResponseWriter, message string, statusCode int) {
 	w.WriteHeader(statusCode)
-	w.Write([]byte(message))
+	tmpl, _ := template.ParseFS(templatesHTML, "templates/partials/error.tmpl")
+	tmpl.ExecuteTemplate(w, "error", struct{ ErrorMessage string }{ErrorMessage: message})
 }
 
 func fileNameWithoutExtension(fileName string) string {

--- a/pkg/files/file_factory.go
+++ b/pkg/files/file_factory.go
@@ -26,6 +26,6 @@ func BuildFactory(f string, filename string) (FileFactory, error) {
 	case Doc, Application:
 		return NewDocumentFactory(filename), nil
 	default:
-		return nil, fmt.Errorf("factory with id %s not recognized", f)
+		return nil, fmt.Errorf("factory with type file %s not recognized", f)
 	}
 }

--- a/static/response-targets.js
+++ b/static/response-targets.js
@@ -1,0 +1,130 @@
+(function(){
+
+    /** @type {import("../htmx").HtmxInternalApi} */
+    var api;
+
+    var attrPrefix = 'hx-target-';
+
+    // IE11 doesn't support string.startsWith
+    function startsWith(str, prefix) {
+        return str.substring(0, prefix.length) === prefix
+    }
+
+    /**
+     * @param {HTMLElement} elt
+     * @param {number} respCode
+     * @returns {HTMLElement | null}
+     */
+    function getRespCodeTarget(elt, respCodeNumber) {
+        if (!elt || !respCodeNumber) return null;
+
+        var respCode = respCodeNumber.toString();
+
+        // '*' is the original syntax, as the obvious character for a wildcard.
+        // The 'x' alternative was added for maximum compatibility with HTML
+        // templating engines, due to ambiguity around which characters are
+        // supported in HTML attributes.
+        //
+        // Start with the most specific possible attribute and generalize from
+        // there.
+        var attrPossibilities = [
+            respCode,
+
+            respCode.substr(0, 2) + '*',
+            respCode.substr(0, 2) + 'x',
+
+            respCode.substr(0, 1) + '*',
+            respCode.substr(0, 1) + 'x',
+            respCode.substr(0, 1) + '**',
+            respCode.substr(0, 1) + 'xx',
+
+            '*',
+            'x',
+            '***',
+            'xxx',
+        ];
+        if (startsWith(respCode, '4') || startsWith(respCode, '5')) {
+            attrPossibilities.push('error');
+        }
+
+        for (var i = 0; i < attrPossibilities.length; i++) {
+            var attr = attrPrefix + attrPossibilities[i];
+            var attrValue = api.getClosestAttributeValue(elt, attr);
+            if (attrValue) {
+                if (attrValue === "this") {
+                    return api.findThisElement(elt, attr);
+                } else {
+                    return api.querySelectorExt(elt, attrValue);
+                }
+            }
+        }
+        
+        return null;
+    }
+
+    /** @param {Event} evt */
+    function handleErrorFlag(evt) {
+        if (evt.detail.isError) {
+            if (htmx.config.responseTargetUnsetsError) {
+                evt.detail.isError = false;
+            }
+        } else if (htmx.config.responseTargetSetsError) {
+            evt.detail.isError = true;
+        }
+    }
+
+    htmx.defineExtension('response-targets', {
+
+        /** @param {import("../htmx").HtmxInternalApi} apiRef */
+        init: function (apiRef) {
+            api = apiRef;
+
+            if (htmx.config.responseTargetUnsetsError === undefined) {
+                htmx.config.responseTargetUnsetsError = true;
+            }
+            if (htmx.config.responseTargetSetsError === undefined) {
+                htmx.config.responseTargetSetsError = false;
+            }
+            if (htmx.config.responseTargetPrefersExisting === undefined) {
+                htmx.config.responseTargetPrefersExisting = false;
+            }
+            if (htmx.config.responseTargetPrefersRetargetHeader === undefined) {
+                htmx.config.responseTargetPrefersRetargetHeader = true;
+            }
+        },
+
+        /**
+         * @param {string} name
+         * @param {Event} evt
+         */
+        onEvent: function (name, evt) {
+            if (name === "htmx:beforeSwap"    &&
+                evt.detail.xhr                &&
+                evt.detail.xhr.status !== 200) {
+                if (evt.detail.target) {
+                    if (htmx.config.responseTargetPrefersExisting) {
+                        evt.detail.shouldSwap = true;
+                        handleErrorFlag(evt);
+                        return true;
+                    }
+                    if (htmx.config.responseTargetPrefersRetargetHeader &&
+                        evt.detail.xhr.getAllResponseHeaders().match(/HX-Retarget:/i)) {
+                        evt.detail.shouldSwap = true;
+                        handleErrorFlag(evt);
+                        return true;
+                    }
+                }
+                if (!evt.detail.requestConfig) {
+                    return true;
+                }
+                var target = getRespCodeTarget(evt.detail.requestConfig.elt, evt.detail.xhr.status);
+                if (target) {
+                    handleErrorFlag(evt);
+                    evt.detail.shouldSwap = true;
+                    evt.detail.target = target;
+                }
+                return true;
+            }
+        }
+    });
+})();

--- a/templates/partials/error.tmpl
+++ b/templates/partials/error.tmpl
@@ -1,0 +1,7 @@
+{{ block "error" .}}
+<div class="col-sm-7">
+  <div class="alert alert-danger" role="alert">
+  {{ .ErrorMessage }}
+  </div>
+</div>
+{{ end }}

--- a/templates/partials/form.tmpl
+++ b/templates/partials/form.tmpl
@@ -2,12 +2,13 @@
 
 {{define "content"}}
 <div class="row align-items-center" style="height: 50vh;">
-  <div class="mx-auto col-10 col-md-8 col-lg-6">
+  <div class="mx-auto col-10 col-md-8 col-lg-6" hx-ext="response-targets">
     <form id="form"
           hx-encoding="multipart/form-data"
           hx-post="/upload"
           hx-swap="outerHTML"
-          hx-indicator="#spinner">
+          hx-indicator="#spinner"
+          hx-target-error="#any-errors">
       <h2>File Converter</h2>
       <div class="row g-3">
         <div class="col-sm-7">
@@ -42,6 +43,7 @@
           </button>
           <progress id='progress' class='htmx-indicator' value='0' max='100'></progress>
         </div>
+        <div id="any-errors"></div>
       </div>
     </form>
   </div>

--- a/templates/partials/htmx.tmpl
+++ b/templates/partials/htmx.tmpl
@@ -1,3 +1,4 @@
 {{define "htmx"}}
   <script src="/static/htmx.min.js"></script>
+  <script src="/static/response-targets.js"></script>
 {{end}}


### PR DESCRIPTION
## Add idiomatic error handling

## Description

Since the very beginning of the project, I thought that the way I was handling errors was tech debt. So, I went ahead and applied a pattern that found interesting while reading through this [article](https://boldlygo.tech/posts/2024-01-08-error-handling/). I just adapted it to my needs by changing some details. 

Changes introduced in this PR:
*  Change the `HandlerFunc` of the `handlers`  to `func(w http.ResponseWriter, r *http.Request) error`
* `renderError` function now executes a error template located at `templates/partials/error.tmpl`
* Such templates is shown to the user when an error occurs
* Add a `statusErr` struct that represents the errors at the HTTP layer

![Screenshot from 2024-03-26 22-18-59](https://github.com/danvergara/morphos/assets/12239167/9789808d-a95f-49f6-bcfd-1275e801b015)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested locally by running into known errors or unintended behaviors.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
