### PR TITLE
refactor the ConvertTo method to receive and return an object that implements the io reader

### DIFF
--- a/pkg/files/documents/documents_test.go
+++ b/pkg/files/documents/documents_test.go
@@ -1,6 +1,8 @@
 package documents_test
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"testing"
 
@@ -12,7 +14,7 @@ import (
 
 type filer interface {
 	SupportedFormats() map[string][]string
-	ConvertTo(string, string, []byte) ([]byte, error)
+	ConvertTo(string, string, io.Reader) (io.Reader, error)
 }
 
 type documenter interface {
@@ -117,12 +119,17 @@ func TestPDFTConvertTo(t *testing.T) {
 			outoutFile, err := tc.input.documenter.ConvertTo(
 				tc.input.targetFileType,
 				tc.input.targetFormat,
-				inputDoc,
+				bytes.NewReader(inputDoc),
 			)
 
 			require.NoError(t, err)
 
-			detectedFileType = mimetype.Detect(outoutFile)
+			buf := new(bytes.Buffer)
+			_, err = buf.ReadFrom(outoutFile)
+			require.NoError(t, err)
+
+			outoutFileBytes := buf.Bytes()
+			detectedFileType = mimetype.Detect(outoutFileBytes)
 			require.Equal(t, tc.expected.mimetype, detectedFileType.String())
 		})
 	}
@@ -175,12 +182,17 @@ func TestDOCXTConvertTo(t *testing.T) {
 			resultFile, err := tc.input.documenter.ConvertTo(
 				tc.input.targetFileType,
 				tc.input.targetFormat,
-				inputDoc,
+				bytes.NewReader(inputDoc),
 			)
 
 			require.NoError(t, err)
 
-			detectedFileType = mimetype.Detect(resultFile)
+			buf := new(bytes.Buffer)
+			_, err = buf.ReadFrom(resultFile)
+			require.NoError(t, err)
+
+			resultFileBytes := buf.Bytes()
+			detectedFileType = mimetype.Detect(resultFileBytes)
 			require.Equal(t, tc.expected.mimetype, detectedFileType.String())
 		})
 	}

--- a/pkg/files/documents/docx.go
+++ b/pkg/files/documents/docx.go
@@ -53,7 +53,7 @@ func (d *Docx) SupportedMIMETypes() map[string][]string {
 	return d.compatibleMIMETypes
 }
 
-func (d *Docx) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, error) {
+func (d *Docx) ConvertTo(fileType, subType string, file io.Reader) (io.Reader, error) {
 	compatibleFormats, ok := d.SupportedFormats()[fileType]
 	if !ok {
 		return nil, fmt.Errorf("file type not supported: %s", fileType)
@@ -62,6 +62,15 @@ func (d *Docx) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, er
 	if !slices.Contains(compatibleFormats, subType) {
 		return nil, fmt.Errorf("sub-type not supported: %s", subType)
 	}
+
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(file); err != nil {
+		return nil, fmt.Errorf(
+			"error getting the content of the docx file in form of slice of bytes: %w",
+			err,
+		)
+	}
+	fileBytes := buf.Bytes()
 
 	switch strings.ToLower(fileType) {
 	case documentType:
@@ -188,7 +197,7 @@ func (d *Docx) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, er
 				return nil, fmt.Errorf("error reading zip file: %v", err)
 			}
 
-			return zipFile, nil
+			return bytes.NewReader(zipFile), nil
 		}
 	}
 

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -1,5 +1,7 @@
 package files
 
+import "io"
+
 // File interface is the main interface of the package,
 // that defines what a file is in this context.
 // It's moslty responsible to say other entitites what formats it can be converted to
@@ -13,7 +15,7 @@ package files
 type File interface {
 	SupportedFormats() map[string][]string
 	SupportedMIMETypes() map[string][]string
-	ConvertTo(string, string, []byte) ([]byte, error)
+	ConvertTo(string, string, io.Reader) (io.Reader, error)
 }
 
 // SupportedFileTypes returns a map with the underlying file type,

--- a/pkg/files/images/bmp.go
+++ b/pkg/files/images/bmp.go
@@ -3,6 +3,7 @@ package images
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 
@@ -64,7 +65,7 @@ func (b *Bmp) SupportedMIMETypes() map[string][]string {
 // ConvertTo method converts a given file to a target format.
 // This method returns a file in form of a slice of bytes.
 // The methd receives a file type and the sub-type of the target format and the file as array of bytes.
-func (b *Bmp) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, error) {
+func (b *Bmp) ConvertTo(fileType, subType string, file io.Reader) (io.Reader, error) {
 	var result []byte
 
 	compatibleFormats, ok := b.SupportedFormats()[fileType]
@@ -78,7 +79,7 @@ func (b *Bmp) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, err
 
 	switch strings.ToLower(fileType) {
 	case imageType:
-		img, err := bmp.Decode(bytes.NewReader(fileBytes))
+		img, err := bmp.Decode(file)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +92,7 @@ func (b *Bmp) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, err
 			)
 		}
 	case documentType:
-		img, err := bmp.Decode(bytes.NewReader(fileBytes))
+		img, err := bmp.Decode(file)
 		if err != nil {
 			return nil, err
 		}
@@ -105,7 +106,7 @@ func (b *Bmp) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, err
 		}
 	}
 
-	return result, nil
+	return bytes.NewReader(result), nil
 }
 
 // ImageType returns the file format of the current image.

--- a/pkg/files/images/gif.go
+++ b/pkg/files/images/gif.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"image/gif"
+	"io"
 	"slices"
 	"strings"
 )
@@ -63,7 +64,7 @@ func (g *Gif) SupportedMIMETypes() map[string][]string {
 // ConvertTo method converts a given file to a target format.
 // This method returns a file in form of a slice of bytes.
 // The methd receives a file type and the sub-type of the target format and the file as array of bytes.
-func (g *Gif) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, error) {
+func (g *Gif) ConvertTo(fileType, subType string, file io.Reader) (io.Reader, error) {
 	var result []byte
 
 	compatibleFormats, ok := g.SupportedFormats()[fileType]
@@ -77,7 +78,7 @@ func (g *Gif) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, err
 
 	switch strings.ToLower(fileType) {
 	case imageType:
-		img, err := gif.Decode(bytes.NewReader(fileBytes))
+		img, err := gif.Decode(file)
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +91,7 @@ func (g *Gif) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, err
 			)
 		}
 	case documentType:
-		img, err := gif.Decode(bytes.NewReader(fileBytes))
+		img, err := gif.Decode(file)
 		if err != nil {
 			return nil, err
 		}
@@ -104,7 +105,7 @@ func (g *Gif) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, err
 		}
 	}
 
-	return result, nil
+	return bytes.NewReader(result), nil
 }
 
 // ImageType returns the file format of the current image.

--- a/pkg/files/images/jpeg.go
+++ b/pkg/files/images/jpeg.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"image/draw"
 	"image/jpeg"
+	"io"
 	"slices"
 	"strings"
 )
@@ -64,7 +65,7 @@ func (j *Jpeg) SupportedMIMETypes() map[string][]string {
 // ConvertTo method converts a given file to a target format.
 // This method returns a file in form of a slice of bytes.
 // The methd receives a file type and the sub-type of the target format and the file as array of bytes.
-func (j *Jpeg) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, error) {
+func (j *Jpeg) ConvertTo(fileType, subType string, file io.Reader) (io.Reader, error) {
 	var result []byte
 
 	compatibleFormats, ok := j.SupportedFormats()[fileType]
@@ -78,7 +79,7 @@ func (j *Jpeg) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, er
 
 	switch strings.ToLower(fileType) {
 	case imageType:
-		img, err := jpeg.Decode(bytes.NewReader(fileBytes))
+		img, err := jpeg.Decode(file)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +92,7 @@ func (j *Jpeg) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, er
 			)
 		}
 	case documentType:
-		img, err := jpeg.Decode(bytes.NewReader(fileBytes))
+		img, err := jpeg.Decode(file)
 		if err != nil {
 			return nil, err
 		}
@@ -108,7 +109,7 @@ func (j *Jpeg) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, er
 		}
 	}
 
-	return result, nil
+	return bytes.NewReader(result), nil
 }
 
 // ImageType returns the file format of the current image.

--- a/pkg/files/images/png.go
+++ b/pkg/files/images/png.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"image/draw"
 	"image/png"
+	"io"
 	"slices"
 	"strings"
 )
@@ -64,7 +65,7 @@ func (p *Png) SupportedMIMETypes() map[string][]string {
 
 // ConvertTo method converts a given file to a target format.
 // This method returns a file in form of a slice of bytes.
-func (p *Png) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, error) {
+func (p *Png) ConvertTo(fileType, subType string, file io.Reader) (io.Reader, error) {
 	var result []byte
 
 	compatibleFormats, ok := p.SupportedFormats()[fileType]
@@ -78,7 +79,7 @@ func (p *Png) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, err
 
 	switch strings.ToLower(fileType) {
 	case imageType:
-		img, err := png.Decode(bytes.NewReader(fileBytes))
+		img, err := png.Decode(file)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +92,7 @@ func (p *Png) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, err
 			)
 		}
 	case documentType:
-		img, err := png.Decode(bytes.NewReader(fileBytes))
+		img, err := png.Decode(file)
 		if err != nil {
 			return nil, err
 		}
@@ -108,7 +109,7 @@ func (p *Png) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, err
 		}
 	}
 
-	return result, nil
+	return bytes.NewReader(result), nil
 }
 
 // ImageType returns the file format of the current image.

--- a/pkg/files/images/tiff.go
+++ b/pkg/files/images/tiff.go
@@ -3,6 +3,7 @@ package images
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 
@@ -63,7 +64,7 @@ func (t *Tiff) SupportedMIMETypes() map[string][]string {
 
 // ConvertTo method converts a given file to a target format.
 // This method returns a file in form of a slice of bytes.
-func (t *Tiff) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, error) {
+func (t *Tiff) ConvertTo(fileType, subType string, file io.Reader) (io.Reader, error) {
 
 	var result []byte
 
@@ -78,7 +79,7 @@ func (t *Tiff) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, er
 
 	switch strings.ToLower(fileType) {
 	case imageType:
-		img, err := tiff.Decode(bytes.NewReader(fileBytes))
+		img, err := tiff.Decode(file)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +92,7 @@ func (t *Tiff) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, er
 			)
 		}
 	case documentType:
-		img, err := tiff.Decode(bytes.NewReader(fileBytes))
+		img, err := tiff.Decode(file)
 		if err != nil {
 			return nil, err
 		}
@@ -105,7 +106,7 @@ func (t *Tiff) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, er
 		}
 	}
 
-	return result, nil
+	return bytes.NewReader(result), nil
 }
 
 // ImageType returns the file format of the current image.

--- a/pkg/files/images/webp.go
+++ b/pkg/files/images/webp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"image"
 	"image/draw"
+	"io"
 	"slices"
 	"strings"
 
@@ -65,7 +66,7 @@ func (w *Webp) SupportedMIMETypes() map[string][]string {
 
 // ConvertTo method converts a given file to a target format.
 // This method returns a file in form of a slice of bytes.
-func (w *Webp) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, error) {
+func (w *Webp) ConvertTo(fileType, subType string, file io.Reader) (io.Reader, error) {
 
 	var result []byte
 
@@ -80,7 +81,7 @@ func (w *Webp) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, er
 
 	switch strings.ToLower(fileType) {
 	case imageType:
-		img, err := webp.Decode(bytes.NewReader(fileBytes))
+		img, err := webp.Decode(file)
 		if err != nil {
 			return nil, err
 		}
@@ -93,7 +94,7 @@ func (w *Webp) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, er
 			)
 		}
 	case documentType:
-		img, err := webp.Decode(bytes.NewReader(fileBytes))
+		img, err := webp.Decode(file)
 		if err != nil {
 			return nil, err
 		}
@@ -110,7 +111,7 @@ func (w *Webp) ConvertTo(fileType, subType string, fileBytes []byte) ([]byte, er
 		}
 	}
 
-	return result, nil
+	return bytes.NewReader(result), nil
 }
 
 // ImageType method returns the file format of the current image.


### PR DESCRIPTION
# Big Refactor on `Converto` signature

## Description

This PR changes the signature of one of the methods  of the `File` interface.
From:

```go
ConvertTo(string, string, []byte) ([]byte, error)
```

To:

```go
ConvertTo(string, string, io.Reader) (io.Reader, error)
```

The reasoning behind this changes is that, since we're working with files, we should be working with the abstraction of that, rather than working inner representation of the file. The benefit is that if the file is too large, we could split it into multiple chunks and process a stream of data.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested it locally running the tests and I QA'd this with different kind of files.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
