### PR TITLE
Improve styling

### DIFF
--- a/templates/partials/card_file.tmpl
+++ b/templates/partials/card_file.tmpl
@@ -1,48 +1,42 @@
 {{define "title"}}Download your file{{end}}
 {{define "content"}}
-  <div class="row align-items-center" style="height: 50vh;">
-    <div class="mx-auto col-10 col-md-8 col-lg-8">
-      <div class="card-group">
-        <div class="card text-center">
-          <div class="card-body">
-            <p class="card-text">
+  <div class="row align-items-center text-center" style="height: 50vh;">
+      <div class="mx-auto col-10">
+        <div class="card-group">
+          <div class="card">
+            <div class="card-body" id="filename" title="{{ .Filename }}">
               {{ .Filename }}
-            </p>
+            </div>
           </div>
-        </div>
-        <div class="card text-center">
-          <div class="card-body text-success">
-            <p>
+          <div class="card text-success">
+            <div class="card-body">
               Finished
-            </p>
+            </div>
           </div>
-        </div>
-        <div class="card text-center">
-          <div class="card-body">
-            <input type="hidden" name="filename" value="{{ .Filename }}" id="filename"></input>
-            <input type="hidden" name="filetype" value="{{ .FileType }}" id="filetype"></input>
-            <button hx-get="/modal"
-                    hx-target="#modals-here"
-                    hx-trigger="click"
-                    hx-include="[name='filename'],[name='filetype']"
-                    hx-params="*"
-                    data-bs-toggle="modal"
-                    data-bs-target="#modals-here"
-                    class="btn btn-success">
-              Download
-            </button>
+          <div class="card">
+            <div class="card-body">
+              <input type="hidden" name="filename" value="{{ .Filename }}" id="filename"></input>
+              <input type="hidden" name="filetype" value="{{ .FileType }}" id="filetype"></input>
+              <button hx-get="/modal"
+                      hx-target="#modals-here"
+                      hx-trigger="click"
+                      hx-include="[name='filename'],[name='filetype']"
+                      hx-params="*"
+                      data-bs-toggle="modal"
+                      data-bs-target="#modals-here"
+                      class="btn btn-success">
+                Download
+              </button>
+            </div>
           </div>
-        </div>
-        <div class="card border-light">
-          <div class="card-body">
-            <p class="card-text">
-              <a href='/'>
+          <div class="card">
+            <div class="card-body">
+              <a href="/">
                 <button type="button" class="btn-close" aria-label="Close"></button>
               </a>
-            </p>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
 {{end}}

--- a/templates/partials/form.tmpl
+++ b/templates/partials/form.tmpl
@@ -2,7 +2,7 @@
 
 {{define "content"}}
 <div class="row align-items-center" style="height: 50vh;">
-  <div class="mx-auto col-10 col-md-8 col-lg-6" hx-ext="response-targets">
+  <div class="mx-auto col-10" hx-ext="response-targets">
     <form id="form"
           hx-encoding="multipart/form-data"
           hx-post="/upload"

--- a/templates/partials/js.tmpl
+++ b/templates/partials/js.tmpl
@@ -6,10 +6,10 @@
   </script>
   <script src="/static/bootstrap.min.js"></script>
   <script>
-    // Shorten the filename if it's too long to fit in the space available
     htmx.on('htmx:load', function(evt) { updateName(); });
     htmx.on(window, 'resize', function(evt) { updateName(); });
 
+    // Shorten the filename if it's too long to fit in the space available
     function updateName() {
       let filenameObj = document.getElementById('filename');
       if (!filenameObj) return; // Not on the download page

--- a/templates/partials/js.tmpl
+++ b/templates/partials/js.tmpl
@@ -5,4 +5,37 @@
     });
   </script>
   <script src="/static/bootstrap.min.js"></script>
+  <script>
+    // Shorten the filename if it's too long to fit in the space available
+    htmx.on('htmx:load', function(evt) { updateName(); });
+    htmx.on(window, 'resize', function(evt) { updateName(); });
+
+    function updateName() {
+      let filenameObj = document.getElementById('filename');
+      if (!filenameObj) return; // Not on the download page
+
+      let filename = filenameObj.title;
+
+      let availableWidth = filenameObj.clientWidth;
+
+      // Calculate the width of the text using character width estimates
+      let textWidth = filename.split('').reduce((acc, c) => acc + (c === ' ' ? 5 : 10), 0);
+      
+      if (textWidth > availableWidth) {
+        let i = 0;
+        let width = 60; // Allows space for ellipsis and end of filename including extension
+
+        // Find the last space before the filename would overflow the available width
+        while (i < filename.length && width < availableWidth) {
+          width += filename[i] === ' ' ? 5 : 10;
+          i++;
+        }
+
+        // Shorten the filename and add an ellipsis
+        filename = filename.substr(0, i) + '...' + filename.substr(filename.length-6, filename.length);
+      }
+
+      filenameObj.innerText = filename;
+    }
+  </script>
 {{end}}

--- a/templates/partials/style.tmpl
+++ b/templates/partials/style.tmpl
@@ -1,3 +1,10 @@
 {{define "style"}}
   <link href="/static/bootstrap.min.css" rel="stylesheet"></link>
+  <style>
+    .card-body {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+  </style>
 {{end}}


### PR DESCRIPTION
# Improve styling

## Description

This is to improve the styling, mainly of the download list which often gets misshapen by long file names. The filename has a title on it so now when you hover over the card you can see the full name.

Happy to make more changes if you aren't happy with it.

## Type of change

- [x] Style

## How Has This Been Tested?

Visually.

![Home page](https://github.com/danvergara/morphos/assets/52386683/1abc6ae5-0c7e-4a0a-b6b8-e0c9b07c7a65)

![Download page](https://github.com/danvergara/morphos/assets/52386683/201809d7-aa96-4fe6-8817-19508ea40099)

![Mobile download page](https://github.com/danvergara/morphos/assets/52386683/d4065740-2855-4bce-a192-525b4dd7bdff)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation *None needed?*
- [ ] I have added tests that prove my fix is effective or that my feature works 
- [x] New and **existing** unit tests pass with my changes
- [x] I have checked my code and corrected any misspellings
